### PR TITLE
reactor: Always retry waitpid

### DIFF
--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -599,6 +599,7 @@ private:
     void add_timer(timer<manual_clock>*) noexcept;
     bool queue_timer(timer<manual_clock>*) noexcept;
     void del_timer(timer<manual_clock>*) noexcept;
+    future<int> do_waitpid(pid_t pid);
 
     future<> run_exit_tasks();
     void stop();


### PR DESCRIPTION
A possible issue with how Docker Desktop v4.34+ (particulary on macOS) handles `pidfd` functionality causes an assertion failure in Seastar's `reactor::waitpid` method.

The issue:

- Seastar creates a `pidfd` using `pidfd_open`
- It polls this file descriptor until it becomes readable
- When readable, call `waitpid` with `WNOHANG`.  According to [pidfd_open](https://man7.org/linux/man-pages/man2/pidfd_open.2.html), the file descriptor becomes readable when the process terminates
- Seastar expects `waitpid` to either return a positive integer representing the child process that has ended or a negative value to indicate an error.  However if `waitpid` returns `0`, then Seastar asserts, crashing the using application.

This change adds `reactor::do_waitpid` which loops on calling `waitpid` until it returns a non-zero value.  This method is called both when a `pidfd` is in use and when it isn't.  The assertion is also removed.